### PR TITLE
Added "close" method to close its form.

### DIFF
--- a/views/form.py
+++ b/views/form.py
@@ -3,14 +3,15 @@ from Tkinter import *
 
 class Form(Frame):
 
-    root = None
-
     def __init__(self, master):
         Frame.__init__(self, master)
-        Form.root = master
+        self.master = master
 
     def _initialize(self, master):
         pass
 
     def _initialize_view(self, master):
         pass
+
+    def close(self):
+        self.master.destroy()

--- a/views/formchatbox.py
+++ b/views/formchatbox.py
@@ -55,7 +55,7 @@ class FormChatbox(Form):
             if isSuccess:
 				print("Already Logout...")
 
-				Form.root.destroy()
+                                self.close()
 				from formlogin import FormLogin
 				loginbox = Tk()
 				loginbox.title("fbChat")

--- a/views/formlogin.py
+++ b/views/formlogin.py
@@ -36,7 +36,7 @@ class FormLogin(Form):
         username = self.username.get()
         password = self.password.get()
         client = login(username, password)
-        Form.root.destroy()
+        self.close()
         from formchatbox import FormChatbox
         chatbox = Tk()
         chatbox.title("fbChat")


### PR DESCRIPTION
In #24 , I see the need for destroy prevoius form because the var "root" is re-assign everytime the form is create. This cause the root to point in the new form and lost the previous root completely whenever we want to create new form. This should solve this problem by keep its root's form ref to its own member call "master", make method call "close" and eliminate the need of var "root" in class "Form"