### PR TITLE
add enable enter key to login

### DIFF
--- a/views/formlogin.py
+++ b/views/formlogin.py
@@ -27,6 +27,7 @@ class FormLogin(Form):
         self.master.title("fbChat")
         self.master.geometry("350x300+600+300")
         self.master.config(bg='#E9EBEE')
+	self.master.bind("<Return>", self._on_buttonlogin_clicked)
         fbphoto = PhotoImage(file='img/FB-f-Logo_blue_58.gif')
         self.fbImageFrame = Frame(master,width=350,height=30,bg='#4267B2')
         self.fblogo = Label(master, image=fbphoto)
@@ -52,7 +53,7 @@ class FormLogin(Form):
         self.entrypass.grid(row=5, column=0,pady=5,ipady=5)
         self.buttonlogin.grid(row=6, column=0, columnspan=2,pady=5)
 
-    def _on_buttonlogin_clicked(self):
+    def _on_buttonlogin_clicked(self, event=None):
         username = self.username.get()
         password = self.password.get()
         try:

--- a/views/formloginfailure.py
+++ b/views/formloginfailure.py
@@ -23,7 +23,10 @@ class FormLoginFailure(Form):
         self.master.geometry("350x200+600+300")
         self.master.config(bg="#E9EBEE")
         self.master.resizable(0,0)
-        self.master.overrideredirect(1)
+
+	self.master.bind("<Return>", self._on_loginagainbutton_clicked)
+        #self.master.overrideredirect(1)
+
         # change the font accordingly
         #self.someFont = font.Font(family='Ubuntu', size=10, weight='normal')
 
@@ -44,7 +47,7 @@ class FormLoginFailure(Form):
                                          bg="#3B5998",fg="#FFFFFB",activebackground="#365899",activeforeground="#FFFFFB")
         self.loginagainbutton.grid(row=2,column=0,pady=30,ipady=5,padx=10)
 
-    def _on_loginagainbutton_clicked(self):
+    def _on_loginagainbutton_clicked(self, event=None):
         self.close()
         try:
             from .formlogin import FormLogin


### PR DESCRIPTION
I created another PR to adopt the functionality of logging in with enter key to the new interface and closed #42
@HarowitzBlack , apparently, there is a conflict between `bind` and  `overrideredirect` (1) methods. I disabled the `overrideredirect` because I think it is okay if users just wanna close the window if a login failure happens. Tell me what you think.

(1) https://stackoverflow.com/questions/31664537/unable-to-bind-keypress-in-tkinter